### PR TITLE
Escape Newlines

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,7 @@ where
     let mut has_carriage_return_char = false;
 
     for b in input.bytes() {
-        if b == b',' || b == b';' || b == b'\\' || b == b'\n'{
+        if b == b',' || b == b';' || b == b'\\' || b == b'\n' {
             escaped_chars_count += 1;
         } else if b == b'\r' {
             has_carriage_return_char = true;
@@ -39,11 +39,11 @@ where
                     if input.get(start + 1..start + 2) != Some("\n") {
                         output.push_str("\\n");
                     }
-                },
+                }
                 // Newlines needs to be escaped to the literal `\n`
                 "\n" => {
                     output.push_str("\\n");
-                },
+                }
                 c => {
                     output.push('\\');
                     output.push_str(c);

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 /// use ics::escape_text;
 ///
 /// let line = "Hello, World! Today is a beautiful day to test: Escape Methods.\n Characters like ; or \\ must be escaped.";
-/// let expected = "Hello\\, World! Today is a beautiful day to test: Escape Methods.\n Characters like \\; or \\\\ must be escaped.";
+/// let expected = "Hello\\, World! Today is a beautiful day to test: Escape Methods.\\n Characters like \\; or \\\\ must be escaped.";
 /// assert_eq!(expected, escape_text(line));
 pub fn escape_text<'a, S>(input: S) -> Cow<'a, str>
 where
@@ -20,7 +20,7 @@ where
     let mut has_carriage_return_char = false;
 
     for b in input.bytes() {
-        if b == b',' || b == b';' || b == b'\\' {
+        if b == b',' || b == b';' || b == b'\\' || b == b'\n'{
             escaped_chars_count += 1;
         } else if b == b'\r' {
             has_carriage_return_char = true;
@@ -28,7 +28,7 @@ where
     }
 
     if has_carriage_return_char || escaped_chars_count > 0 {
-        let escaped_chars = |c| c == ',' || c == ';' || c == '\\' || c == '\r';
+        let escaped_chars = |c| c == ',' || c == ';' || c == '\\' || c == '\r' || c == '\n';
         let mut output = String::with_capacity(input.len() + escaped_chars_count);
         let mut last_end = 0;
         for (start, part) in input.match_indices(escaped_chars) {
@@ -37,9 +37,13 @@ where
                 // \r was in old MacOS versions the newline character
                 "\r" => {
                     if input.get(start + 1..start + 2) != Some("\n") {
-                        output.push('\n');
+                        output.push_str("\\n");
                     }
-                }
+                },
+                // Newlines needs to be escaped to the literal `\n`
+                "\n" => {
+                    output.push_str("\\n");
+                },
                 c => {
                     output.push('\\');
                     output.push_str(c);
@@ -61,7 +65,7 @@ mod escape_text_tests {
     #[test]
     fn escaped_chars() {
         let s = ",\r\n;:\\ \r\n\rö\r";
-        let expected = "\\,\n\\;:\\\\ \n\nö\n";
+        let expected = "\\,\\n\\;:\\\\ \\n\\nö\\n";
         assert_eq!(expected, escape_text(s));
     }
 
@@ -77,7 +81,7 @@ mod escape_text_tests {
     fn escape_property() {
         use components::Property;
 
-        let expected_value = "Hello\\, World! Today is a beautiful day to test: Escape Methods.\n Characters like \\; or \\\\ must be escaped.\n";
+        let expected_value = "Hello\\, World! Today is a beautiful day to test: Escape Methods.\\n Characters like \\; or \\\\ must be escaped.\\n";
         let property = Property::new(
             "COMMENT",
             escape_text("Hello, World! Today is a beautiful day to test: Escape Methods.\n Characters like ; or \\ must be escaped.\r\n")

--- a/tests/components.rs
+++ b/tests/components.rs
@@ -64,9 +64,9 @@ fn journal() {
     DTSTAMP:19970901T130000Z\r\n\
     DTSTART;VALUE=DATE:19970317\r\n\
     SUMMARY:Staff meeting minutes\r\n\
-    DESCRIPTION:1. Staff meeting: Participants include Joe\\, Lisa\\, and Bob. Au\r\n rora project plans were reviewed. There is currently no budget reserves for\r\n  this project. Lisa will escalate to management. Next meeting on Tuesday.\n\
-    2\r\n . Telephone Conference: ABC Corp. sales representative called to discuss ne\r\n w printer. Promised to get us a demo by Friday.\n\
-    3. Henry Miller (Handsoff I\r\n nsurance): Car was totaled by tree. Is looking into a loaner car. 555-2323 \r\n (tel).\r\n\
+    DESCRIPTION:1. Staff meeting: Participants include Joe\\, Lisa\\, and Bob. Au\r\n rora project plans were reviewed. There is currently no budget reserves for\r\n  this project. Lisa will escalate to management. Next meeting on Tuesday.\\n\
+    \r\n 2. Telephone Conference: ABC Corp. sales representative called to discuss n\r\n ew printer. Promised to get us a demo by Friday.\\n\
+    3. Henry Miller (Handsoff\r\n  Insurance): Car was totaled by tree. Is looking into a loaner car. 555-232\r\n 3 (tel).\r\n\
     END:VJOURNAL\r\n";
 
     let mut journal = Journal::new("b68378cf-872d-44f1-9703-5e3725c56e71", "19970901T130000Z");

--- a/tests/ical.rs
+++ b/tests/ical.rs
@@ -21,8 +21,8 @@ fn icalendar_event() {
                     STATUS:CONFIRMED\r\n\
                     CATEGORIES:CONFERENCE\r\n\
                     SUMMARY:Networld+Interop Conference\r\n\
-                    DESCRIPTION:Networld+Interop Conference and Exhibit\n\
-                    Atlanta World Congress \r\n Center\n\
+                    DESCRIPTION:Networld+Interop Conference and Exhibit\\n\
+                    Atlanta World Congress\r\n  Center\\n\
                     Atlanta\\, Georgia\r\n\
                     END:VEVENT\r\n\
                     END:VCALENDAR\r\n";


### PR DESCRIPTION
According to rfc 5545 newlines should be escaped in `TEXT` values. This is defined in section 3.3.11 (TEXT) as follows:

```text

 ESCAPED-CHAR = ("\\" / "\;" / "\," / "\N" / "\n")
    ; \\ encodes \, \N or \n encodes newline
    ; \; encodes ;, \, encodes ,
```

Unforunately, `util::escape_text` does not care for newlines, and so in this pull request I updated the `util::escape_text` to escape newlines, and changed the tests accordingly.

Thanks for your time!